### PR TITLE
Fix image pasting

### DIFF
--- a/app/components/Editor.js
+++ b/app/components/Editor.js
@@ -116,6 +116,10 @@ export default class Editor extends React.Component {
       setEditorRawText: (rawText) => {
         let cleaned = this.redactor.cleaner.input(rawText);
         $R('#editor', 'source.setCode', cleaned);
+
+        // Required for default end focus because setCode happens to focus at the beginning
+        // This function is called on note load, so this affects 'default' focus
+        this.redactor.editor.endFocus();
       }
     });
 
@@ -178,8 +182,6 @@ export default class Editor extends React.Component {
       });
     });
 
-    // "Set the focus to the editor layer to the end of the content."
-    // Doesn't seem to currently work, focuses at the beginning.
     this.redactor.editor.endFocus();
   }
 

--- a/app/components/Editor.js
+++ b/app/components/Editor.js
@@ -19,6 +19,10 @@ export default class Editor extends React.Component {
   }
 
   configureEditorKit() {
+    // EditorKit is a wrapper on top of the component manager to make it easier to build editors
+    // As such, it very general and does not know how the functions are implemented, just that they are needed 
+    // It is up to the Bold Editor wrapper to implement these important functions
+
     let delegate = new EditorKitDelegate({
       insertRawText: (rawText) => {
         // Used to insert Filesafe file descriptor syntax
@@ -71,8 +75,18 @@ export default class Editor extends React.Component {
         return this.redactor.editor.getElement().find(selector).nodes;
       },
       getCurrentLineText: () => {
-        // Returns the node where the cursor currently is. Typically a paragraph if no formatter, otherwise the closest formatted element
+        // Returns the text content of the node where the cursor currently is. Typically a paragraph if no formatter, otherwise the closest formatted element
         let node = this.redactor.selection.getCurrent();
+
+        // If the node is a figure, remove the <figure> tag and return the child nodes
+        // This is to allow for saving of images, videos, audio when loading Filesafe elements
+        if (node.nodeName === "FIGURE") {
+          let inserted = node.innerHTML;
+          node.remove();
+          this.redactor.insertion.insertHtml(inserted);
+          return inserted;
+        }
+        
         return node.textContent;
       },
       getPreviousLineText: () => {

--- a/app/components/Editor.js
+++ b/app/components/Editor.js
@@ -21,6 +21,7 @@ export default class Editor extends React.Component {
   configureEditorKit() {
     let delegate = new EditorKitDelegate({
       insertRawText: (rawText) => {
+        // Used to insert Filesafe file descriptor syntax
         this.redactor.insertion.insertHtml(rawText);
       },
       preprocessElement: (element) => {
@@ -114,12 +115,15 @@ export default class Editor extends React.Component {
         $R('#editor', 'module.buffer.clear');
       },
       setEditorRawText: (rawText) => {
+        // Get the current caret location
+        let caretLocation = this.redactor.selection.getPosition();
+        let point = {clientX: caretLocation.left, clientY: caretLocation.top};
+
         let cleaned = this.redactor.cleaner.input(rawText);
         $R('#editor', 'source.setCode', cleaned);
 
-        // Required for default end focus because setCode happens to focus at the beginning
-        // This function is called on note load, so this affects 'default' focus
-        this.redactor.editor.endFocus();
+        // Place caret at saved location
+        this.redactor.insertion.insertToPoint(point, "");
       }
     });
 
@@ -192,7 +196,7 @@ export default class Editor extends React.Component {
       return;
     }
     for(let file of files) {
-      // Observers will handle successful upload
+      // Observers in EditorKitInternal.js will handle successful upload
       this.editorKit.uploadJSFileObject(file).then((descriptor) => {
         if(!descriptor || !descriptor.uuid) {
           // alert("File failed to upload. Please try again");

--- a/app/components/Editor.js
+++ b/app/components/Editor.js
@@ -122,8 +122,16 @@ export default class Editor extends React.Component {
         let cleaned = this.redactor.cleaner.input(rawText);
         $R('#editor', 'source.setCode', cleaned);
 
-        // Place caret at saved location
-        this.redactor.insertion.insertToPoint(point, "");
+        // Place caret at saved location, insert custom marker node to avoid inserting newlines
+        let marker = this.redactor.insertion.insertToPoint(point, "<marker>");
+
+        this.redactor.caret.setAfter(marker[0]);
+
+        for (let i = 0; i < marker.length; i++){
+          // Immediately remove the custom marker node
+          // If for whatever reason there is more than one marker, remove them all
+          marker[i].remove();
+        }        
       }
     });
 


### PR DESCRIPTION
This is a fix for the [image pasting issue](https://github.com/standardnotes/bold-editor/issues/17).

New behavior:
* The editor will focus to the end by default (which fixes another bug in the code)
* When an image is pasted and successfully uploaded to Filesafe, it is inserted at the caret location

Side effects:
* When switching between notes, the caret stays in a fixed absolute position

Other considerations:
* We are not using the latest Redactor version, but not sure if updates will fix this problem