### PR TITLE
fix: turn off link shortening

### DIFF
--- a/app/components/Editor.js
+++ b/app/components/Editor.js
@@ -138,6 +138,7 @@ export default class Editor extends React.Component {
       toolbarFixed: true,
       tabAsSpaces: 2, // currently the only way tab works is if you use spaces. Traditional doesnt work
       tabKey: true,
+      linkSize: Infinity,
       buttonsAdd: ['filesafe'],
       buttons: [
         'bold', 'italic', 'underline', 'deleted', 'format', 'fontsize', 'fontfamily',


### PR DESCRIPTION
Redactor has a default setting that automatically truncates a link. Changed the setting to fix issue [here](https://standardnotes.slack.com/archives/C53KUMS1X/p1592830619029700).